### PR TITLE
mrc-213: python support for testing vault in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 __pycache__
+.coverage
+.eggs
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .coverage
 .eggs
 *.egg-info
+build
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python: 3.5
+
+install:
+  - pip3 install codecov
+
+script:
+  - pip3 install -r requirements.txt
+  - coverage run --source=orderly_web setup.py test
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 python: 3.5
 
 install:
-  - pip3 install codecov
+  - pip3 install codecov pytest-cov
 
 script:
   - pip3 install -r requirements.txt
-  - coverage run --source=orderly_web setup.py test
+  - py.test --cov-report  term --cov=vault_dev
 
 after_success:
   - codecov

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Imperial College of Science, Technology and Medicine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## vault-dev
 
+[![Build Status](https://travis-ci.org/vimc/vault-dev.svg?branch=master)](https://travis-ci.org/vimc/vault-dev)
+[![codecov.io](https://codecov.io/github/vimc/vault-dev/coverage.svg?branch=master)](https://codecov.io/github/vimc/vault-dev?branch=master)
+
 Use vault server in development mode in tests, from python
 
 ## Usage:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 ## vault-dev
 
 Use vault server in development mode in tests, from python
+
+## Usage:
+
+```python
+import vault_dev
+vault_dev.ensure_installed()
+# Did not find system vault, installing one for tests
+# installing vault to '/tmp/tmpkzvlyw5c'
+with vault_dev.server(verbose=True) as server:
+  vault = server.client()
+  vault.write("secret/key", value="password")
+# Starting vault server on port 37355
+# Waiting for server to become active
+# .
+# Connection made
+# Configuring old-style kv engine at /secret
+# Stopping vault server
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 Use vault server in development mode in tests, from python
 
+## Installation:
+
+Install with pip
+
+``` shell
+pip3 install --user vault_dev
+```
+
 ## Usage:
 
 ```python
@@ -21,4 +29,12 @@ with vault_dev.server(verbose=True) as server:
 # Connection made
 # Configuring old-style kv engine at /secret
 # Stopping vault server
+```
+
+## Publish to pypi
+
+```shell
+python3 setup.py sdist bdist_wheel
+python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
 ```

--- a/conftest.py
+++ b/conftest.py
@@ -4,8 +4,3 @@ import vault_dev.install
 def pytest_sessionstart(session):
     """ before session.main() is called. """
     vault_dev.install.ensure_installed()
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """ whole test run finishes. """
-    vault_dev.install.cleanup()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import vault_dev.install
+
+# https://stackoverflow.com/a/35394239
+def pytest_sessionstart(session):
+    """ before session.main() is called. """
+    vault_dev.install.ensure_installed()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """ whole test run finishes. """
+    vault_dev.install.cleanup()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+hvac
+pytest
+requests

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setup(name="vault_dev",
-      version="0.0.1",
+      version="0.0.2",
       description="Run vault in dev mode from python scripts",
       long_description=long_description,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setup(name="vault_dev",
+      version="0.0.1",
+      description="Run vault in dev mode from python scripts",
+      long_description=long_description,
+      classifiers=[
+          "Programming Language :: Python :: 3",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: OS Independent",
+      ],
+      url="https://github.com/vimc/vault-dev",
+      author="Rich FitzJohn",
+      author_email="r.fitzjohn@imperial.ac.uk",
+      license='MIT',
+      packages=find_packages(),
+      zip_safe=False,
+      # Extra:
+      long_description_content_type="text/markdown",
+      setup_requires=["pytest-runner"],
+      tests_require=["pytest"],
+      requires=[
+          "hvac",
+          "requests"
+      ])

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -20,28 +20,13 @@ def test_vault_download_skips_existing_file():
 
 
 def test_vault_download():
-    with tempfile.TemporaryDirectory() as path:
-        p = install(path)
-        assert os.path.exists(p)
-
-
-def test_cleanup():
-    assert vault_dev_exe.exists()
-    path = vault_dev_exe().vault(True)
-    tmp = path + ".bak"
-    shutil.copy(path, tmp)
-    cleanup()
-    assert not os.path.exists(path)
-    assert not vault_dev_exe().exists()
-    shutil.copy(tmp, path)
-    assert vault_dev_exe().exists()
+    v = VaultDevExe()
+    p = v.install()
+    assert os.path.exists(p)
+    assert v.vault() == p
 
 
 def test_error_with_no_suitable_vault():
-    p = vault_dev_exe.exe
-    vault_dev_exe.exe = "vault_missing"
-    assert vault_dev_exe.vault(False) is None
+    v = VaultDevExe()
     with pytest.raises(Exception, match="No vault found"):
-        vault_dev_exe.vault(True)
-    vault_dev_exe.exe = p
-    assert vault_dev_exe.vault(True) == p
+        v.vault()

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -1,3 +1,4 @@
+import pytest
 import tempfile
 
 from vault_dev.install import *
@@ -26,11 +27,21 @@ def test_vault_download():
 
 def test_cleanup():
     assert vault_dev_exe.exists()
-    path = vault_dev_exe().vault()
+    path = vault_dev_exe().vault(True)
     tmp = path + ".bak"
     shutil.copy(path, tmp)
-    vault_dev_exe().cleanup()
+    cleanup()
     assert not os.path.exists(path)
     assert not vault_dev_exe().exists()
     shutil.copy(tmp, path)
     assert vault_dev_exe().exists()
+
+
+def test_error_with_no_suitable_vault():
+    p = vault_dev_exe.exe
+    vault_dev_exe.exe = "vault_missing"
+    assert vault_dev_exe.vault(False) is None
+    with pytest.raises(Exception, match="No vault found"):
+        vault_dev_exe.vault(True)
+    vault_dev_exe.exe = p
+    assert vault_dev_exe.vault(True) == p

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -1,0 +1,31 @@
+import tempfile
+
+from vault_dev.install import *
+
+def test_vault_exe_name_correct():
+    assert vault_exe_filename("windows") == "vault.exe"
+    assert vault_exe_filename("linux") == "vault"
+    assert vault_exe_filename("darwin") == "vault"
+
+
+def test_vault_download_skips_existing_file():
+    platform = vault_platform()
+    version = "1.0.0"
+    with tempfile.TemporaryDirectory() as dest:
+        p = "{}/{}".format(dest, vault_exe_filename(platform))
+        open(p, "a").close()
+        assert vault_download(dest, version, platform) == p
+        assert os.path.getsize(p) == 0
+
+
+def test_vault_download():
+    with tempfile.TemporaryDirectory() as path:
+        p = install(path)
+        assert os.path.exists(p)
+
+
+def test_dev_directory_does_not_change():
+    p1 = vault_dev_directory()
+    p2 = vault_dev_directory()
+    assert str(p1) == str(p2)
+    assert repr(p1) == repr(p2)

--- a/test/test_install.py
+++ b/test/test_install.py
@@ -24,8 +24,13 @@ def test_vault_download():
         assert os.path.exists(p)
 
 
-def test_dev_directory_does_not_change():
-    p1 = vault_dev_directory()
-    p2 = vault_dev_directory()
-    assert str(p1) == str(p2)
-    assert repr(p1) == repr(p2)
+def test_cleanup():
+    assert vault_dev_exe.exists()
+    path = vault_dev_exe().vault()
+    tmp = path + ".bak"
+    shutil.copy(path, tmp)
+    vault_dev_exe().cleanup()
+    assert not os.path.exists(path)
+    assert not vault_dev_exe().exists()
+    shutil.copy(tmp, path)
+    assert vault_dev_exe().exists()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,14 +16,3 @@ def test_drop_envvar_ignores_missing_envvar():
     name = "VAULT_DEV_TEST_VAR"
     drop_envvar(name)
     assert name not in os.environ
-
-
-def test_find_executable():
-    assert type(find_executable("ls", None)) == str
-    with tempfile.NamedTemporaryFile() as f:
-        p = find_executable("ls", f.name)
-        assert p == f.name
-    with pytest.raises(OSError, match="not found on path"):
-        find_executable("asdfasdfasdaf", None)
-    with pytest.raises(Exception, match="Path '/missing/path' does not exist"):
-        find_executable("asdfasdfasdaf", "/missing/path")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,15 @@
+import os
+from vault_dev.utils import *
+
+
+def test_drop_envvar_removes_envvar():
+    name = "VAULT_DEV_TEST_VAR"
+    os.environ[name] = "x"
+    drop_envvar(name)
+    assert name not in os.environ
+
+
+def test_drop_envvar_ignores_missing_envvar():
+    name = "VAULT_DEV_TEST_VAR"
+    drop_envvar(name)
+    assert name not in os.environ

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,9 @@
 import os
-from vault_dev.utils import *
+import pytest
+import shutil
+import tempfile
 
+from vault_dev.utils import *
 
 def test_drop_envvar_removes_envvar():
     name = "VAULT_DEV_TEST_VAR"
@@ -13,3 +16,14 @@ def test_drop_envvar_ignores_missing_envvar():
     name = "VAULT_DEV_TEST_VAR"
     drop_envvar(name)
     assert name not in os.environ
+
+
+def test_find_executable():
+    assert type(find_executable("ls", None)) == str
+    with tempfile.NamedTemporaryFile() as f:
+        p = find_executable("ls", f.name)
+        assert p == f.name
+    with pytest.raises(OSError, match="not found on path"):
+        find_executable("asdfasdfasdaf", None)
+    with pytest.raises(Exception, match="Path '/missing/path' does not exist"):
+        find_executable("asdfasdfasdaf", "/missing/path")

--- a/test/test_vault_dev.py
+++ b/test/test_vault_dev.py
@@ -11,7 +11,7 @@ def test_server_basic():
     s.start()
     assert s.is_running()
     cl = s.client()
-    ## check that vault came up ok and that the v1 key-value store works
+    # check that vault came up ok and that the v1 key-value store works
     cl.write("secret/foo", a="b")
     assert cl.read("secret/foo")["data"]["a"] == "b"
     s.stop()
@@ -36,7 +36,7 @@ def test_failure_to_start():
             assert e.code is not None
 
 
-def test_faiure_after_start():
+def test_failure_after_start():
     with vault_dev.server() as s:
         s.start()
         s.token = "root"

--- a/test/test_vault_dev.py
+++ b/test/test_vault_dev.py
@@ -1,9 +1,9 @@
+import gc
 import socket
 import pytest
 
 import vault_dev
 from vault_dev.utils import *
-
 
 def test_server_basic():
     s = vault_dev.server()
@@ -60,3 +60,13 @@ def test_verbose_mode(capsys):
 def test_restart_is_not_an_error():
     with vault_dev.server() as s:
         assert s.start() is None
+
+
+def test_cleanup_on_gc():
+    def f():
+        s = vault_dev.server()
+        s.start()
+        return s.process
+    p = f()
+    gc.collect()
+    assert p.poll() < 0

--- a/test/test_vault_dev.py
+++ b/test/test_vault_dev.py
@@ -1,0 +1,62 @@
+import socket
+import pytest
+
+import vault_dev
+from vault_dev.utils import *
+
+
+def test_server_basic():
+    s = vault_dev.server()
+    assert not s.is_running()
+    s.start()
+    assert s.is_running()
+    cl = s.client()
+    ## check that vault came up ok and that the v1 key-value store works
+    cl.write("secret/foo", a="b")
+    assert cl.read("secret/foo")["data"]["a"] == "b"
+    s.stop()
+    assert not s.is_running()
+
+
+def test_that_enter_exit_works():
+    with vault_dev.server() as s:
+        p = s.process
+        assert s.is_running()
+    assert p.poll()
+
+
+def test_failure_to_start():
+    with socket.socket() as s:
+        s.bind(('localhost', 0))
+        port = s.getsockname()[1]
+        server = vault_dev.server(port)
+        with pytest.raises(vault_dev.VaultDevServerError) as e:
+            server.start()
+            assert e.message == "Vault process has terminated"
+            assert e.code is not None
+
+
+def test_faiure_after_start():
+    with vault_dev.server() as s:
+        s.start()
+        s.token = "root"
+        with pytest.raises(vault_dev.VaultDevServerError) as e:
+            s._wait_until_active(0.5, 0.1)
+            assert e.message == "Vault did not start in time"
+            assert e.code is None
+            assert e.stdout[0].startswith(">> ")
+
+
+def test_verbose_mode(capsys):
+    with vault_dev.server(verbose=True) as s:
+        port = s.port
+    captured = capsys.readouterr().out
+    assert "Starting vault server on port {}".format(port) in captured
+    assert "Waiting for server to become active" in captured
+    assert "Connection made" in captured
+    assert "Configuring old-style kv engine at /secret" in captured
+
+
+def test_restart_is_not_an_error():
+    with vault_dev.server() as s:
+        assert s.start() is None

--- a/test/test_vault_dev.py
+++ b/test/test_vault_dev.py
@@ -32,8 +32,10 @@ def test_failure_to_start():
         server = vault_dev.server(port)
         with pytest.raises(vault_dev.VaultDevServerError) as e:
             server.start()
-            assert e.message == "Vault process has terminated"
+            assert e.msg == "Vault process has terminated"
             assert e.code is not None
+            assert e.msg in str(e.value)
+            assert e.stdout in str(e.value)
 
 
 def test_failure_after_start():
@@ -42,7 +44,7 @@ def test_failure_after_start():
         s.token = "root"
         with pytest.raises(vault_dev.VaultDevServerError) as e:
             s._wait_until_active(0.5, 0.1)
-            assert e.message == "Vault did not start in time"
+            assert e.msg == "Vault did not start in time"
             assert e.code is None
             assert e.stdout[0].startswith(">> ")
 

--- a/test/test_vault_dev.py
+++ b/test/test_vault_dev.py
@@ -10,6 +10,7 @@ def test_server_basic():
     assert not s.is_running()
     s.start()
     assert s.is_running()
+    assert s.url() == "http://localhost:{}".format(s.port)
     cl = s.client()
     # check that vault came up ok and that the v1 key-value store works
     cl.write("secret/foo", a="b")

--- a/vault_dev/__init__.py
+++ b/vault_dev/__init__.py
@@ -1,0 +1,5 @@
+from vault_dev.server import server
+
+__all__ = [
+    server
+]

--- a/vault_dev/__init__.py
+++ b/vault_dev/__init__.py
@@ -1,5 +1,6 @@
-from vault_dev.server import server
+from vault_dev.server import server, VaultDevServerError
 
 __all__ = [
-    server
+    server,
+    VaultDevServerError
 ]

--- a/vault_dev/__init__.py
+++ b/vault_dev/__init__.py
@@ -1,6 +1,8 @@
 from vault_dev.server import server, VaultDevServerError
+from vault_dev.install import ensure_installed
 
 __all__ = [
+    ensure_installed,
     server,
     VaultDevServerError
 ]

--- a/vault_dev/install.py
+++ b/vault_dev/install.py
@@ -1,0 +1,78 @@
+import os
+import platform
+import requests
+import shutil
+import tempfile
+import zipfile
+
+from vault_dev.utils import find_executable
+
+
+def ensure_installed():
+    if not shutil.which("vault"):
+        print("Did not find system vault, installing one for tests")
+        install()
+
+
+def cleanup():
+    if vault_dev_directory.path and os.path.exists(vault_dev_directory.path):
+        print("\nCleaning up the vault directory")
+        shutil.rmtree(vault_dev_directory.path)
+        vault_dev_directory.path = None
+
+
+def vault_path(path):
+    try:
+        vault = find_executable("vault", path)
+    except OSError as e:
+        vault_exe = vault_exe_filename(vault_platform())
+        vault = "{}/{}".format(vault_dev_directory(), vault_exe)
+        if not os.path.exists(vault):
+            raise e
+    return vault
+
+
+def install(dest=None, version="1.0.0", platform=None):
+    if not dest:
+        dest = vault_dev_directory().path
+    return vault_download(dest, version, platform or vault_platform())
+
+
+def vault_exe_filename(platform):
+    if platform == "windows":
+        return "vault.exe"
+    else:
+        return "vault"
+
+
+def vault_url(version, platform, arch = "amd64"):
+    fmt = "https://releases.hashicorp.com/vault/{}/vault_{}_{}_{}.zip"
+    return fmt.format(version, version, platform, arch)
+
+
+def vault_platform():
+    return platform.system().lower()
+
+
+def vault_download(dest, version, platform):
+    dest_bin = "{}/{}".format(dest, vault_exe_filename(platform))
+    if not os.path.exists(dest_bin):
+        print("installing vault to '{}'".format(dest))
+        url = vault_url(version, platform)
+        data = requests.get(url).content
+        with tempfile.TemporaryFile() as tmp:
+            tmp.write(data)
+            tmp.seek(0)
+            z = zipfile.ZipFile(tmp)
+            z.extract(vault_exe_filename(platform), dest)
+        os.chmod(dest_bin, 0o755)
+    return dest_bin
+
+
+class vault_dev_directory:
+    path = None
+    def __init__(self):
+        if not self.path:
+            vault_dev_directory.path = tempfile.TemporaryDirectory().name
+    def __repr__(self):
+        return str(self.path)

--- a/vault_dev/install.py
+++ b/vault_dev/install.py
@@ -22,15 +22,13 @@ def cleanup():
 ##
 ## 1. given path
 ## 2. vault on the system path
-## 3. vault installed by this package
+## 3. vault installed by our package
 ## 4. error
 def vault_path(path):
     try:
         vault = find_executable("vault", path)
     except OSError as e:
-        vault = vault_dev_exe.vault()
-        if not vault:
-            raise e
+        vault = vault_dev_exe.vault(True)
     return vault
 
 
@@ -93,5 +91,10 @@ class vault_dev_exe:
         return vault_dev_exe.exe and os.path.exists(vault_dev_exe.exe)
 
     @staticmethod
-    def vault():
-        return vault_dev_exe.exe if vault_dev_exe.exists() else None
+    def vault(required):
+        if vault_dev_exe.exists():
+            return vault_dev_exe.exe
+        elif not required:
+            return None
+        else:
+            raise Exception("No vault found")

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -94,17 +94,16 @@ class server:
 class VaultDevServerError(Exception):
     def __init__(self, message, process):
         self.code = process.poll()
+        if self.code:
+            status = "Process exited with code {}".format(self.code)
+        else:
+            status = "Process is still running"
         if not self.code:
             print("Killing vault server process")
             process.kill()
             self.code = process.wait()
         self.stdout = read_all_lines(process.stdout, ">> ")
         self.stderr = read_all_lines(process.stderr, ">> ")
-
-        if self.code:
-            status = "Process exited with code {}".format(self.code)
-        else:
-            status = "Process is still running"
         out = self.stdout or "(none)"
         err = self.stderr or "(none)"
         self.msg = message

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -1,5 +1,4 @@
 import math
-import os
 import socket
 import subprocess
 import time
@@ -8,13 +7,12 @@ import uuid
 import hvac
 import requests
 
-from vault_dev.utils import find_free_port
+from vault_dev.utils import find_free_port, read_all_lines, drop_envvar
 
 
 class server:
     def __init__(self, port=None, verbose=False, debug=False):
         self.port = port or find_free_port()
-        self.addr = "http://localhost:{}".format(self.port)
         self.token = str(uuid.uuid4())
         self.debug = debug
         self.verbose = verbose or debug
@@ -40,11 +38,10 @@ class server:
 
     def client(self):
         # See https://github.com/hvac/hvac/issues/421
-        if "VAULT_ADDR" in os.environ:
-            del os.environ["VAULT_ADDR"]
-        if "VAULT_TOKEN" in os.environ:
-            del os.environ["VAULT_TOKEN"]
-        cl = hvac.Client(url=self.addr, token=self.token)
+        drop_envvar("VAULT_ADDR")
+        drop_envvar("VAULT_TOKEN")
+        url = "http://localhost:{}".format(self.port)
+        cl = hvac.Client(url=url, token=self.token)
         assert cl.is_authenticated()
         return cl
 
@@ -62,18 +59,17 @@ class server:
         self._message("Waiting for server to become active")
         for i in range(math.ceil(timeout / poll)):
             if not self.is_running():
-                self._process_output()
-                raise Exception("Vault process has terminated")
+                raise VaultDevServerError("Vault process has terminated",
+                                          self.process)
             try:
                 cl = self.client()
                 if cl.sys.is_initialized():
                     self._message("\nConnection made")
                     return
             except:
-                self._message(".", end="")
+                self._message(".", end="", flush=True)
                 time.sleep(poll)
-        # self._process_output()
-        raise Exception("Vault did not start in time")
+        raise VaultDevServerError("Vault did not start in time", self.process)
 
     def _enable_kv1(self):
         self._message("Configuring old-style kv engine at /secret")
@@ -87,7 +83,24 @@ class server:
         if self.verbose:
             print(txt, **kwargs)
 
-    def _process_output(self):
-        out = self.process.stdout.read().decode("UTF-8") or "(none)"
-        err = self.process.stderr.read().decode("UTF-8") or "(none)"
-        print("\nstdout:\n{}\nstderr:\n{}\n".format(out, err))
+
+class VaultDevServerError(Exception):
+    def __init__(self, message, process):
+        self.message = message
+        self.code = process.poll()
+        if not self.code:
+            print("Killing vault server process")
+            process.kill()
+            self.code = process.wait()
+        self.stdout = read_all_lines(process.stdout, ">> ")
+        self.stderr = read_all_lines(process.stderr, ">> ")
+
+    def __str__(self):
+        if self.code:
+            status = "Process exited with code {}".format(self.code)
+        else:
+            status = "Process is still running"
+        out = self.stdout or "(none)"
+        err = self.stderr or "(none)"
+        return "{}\n{}\nstdout:\n{}\nstderr:\n{}".format(
+            self.message, status, out, err)

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -31,10 +31,12 @@ class server:
         self._wait_until_active(timeout, poll)
         self._enable_kv1()
 
-    def stop(self):
+    def stop(self, wait=True):
         self._message("Stopping vault server")
-        self.process.kill()
-        self.process.wait()
+        if self.is_running():
+            self.process.kill()
+            if wait:
+                self.process.wait()
 
     def client(self):
         # See https://github.com/hvac/hvac/issues/421
@@ -51,6 +53,9 @@ class server:
 
     def __exit__(self, type, value, traceback):
         self.stop()
+
+    def __del__(self):
+        self.stop(False)
 
     def is_running(self):
         return self.process and not self.process.poll()

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -44,10 +44,12 @@ class server:
         # See https://github.com/hvac/hvac/issues/421
         drop_envvar("VAULT_ADDR")
         drop_envvar("VAULT_TOKEN")
-        url = "http://localhost:{}".format(self.port)
-        cl = hvac.Client(url=url, token=self.token)
+        cl = hvac.Client(url=self.url(), token=self.token)
         assert cl.is_authenticated()
         return cl
+
+    def url(self):
+        return "http://localhost:{}".format(self.port)
 
     def __enter__(self):
         self.start()

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -1,0 +1,93 @@
+import math
+import os
+import socket
+import subprocess
+import time
+import uuid
+
+import hvac
+import requests
+
+from vault_dev.utils import find_free_port
+
+
+class server:
+    def __init__(self, port=None, verbose=False, debug=False):
+        self.port = port or find_free_port()
+        self.addr = "http://localhost:{}".format(self.port)
+        self.token = str(uuid.uuid4())
+        self.debug = debug
+        self.verbose = verbose or debug
+        self.process = None
+
+    def start(self, timeout=5, poll=0.1):
+        if self.is_running():
+            self._message("Vault server already started")
+            return
+        self._message("Starting vault server on port {}".format(self.port))
+        args = ["vault", "server", "-dev",
+                "-dev-listen-address", "localhost:{}".format(self.port),
+                "-dev-root-token-id", self.token]
+        output = None if self.debug else subprocess.PIPE
+        self.process = subprocess.Popen(args, stderr=output, stdout=output)
+        self._wait_until_active(timeout, poll)
+        self._enable_kv1()
+
+    def stop(self):
+        self._message("Stopping vault server")
+        self.process.kill()
+        self.process.wait()
+
+    def client(self):
+        # See https://github.com/hvac/hvac/issues/421
+        if "VAULT_ADDR" in os.environ:
+            del os.environ["VAULT_ADDR"]
+        if "VAULT_TOKEN" in os.environ:
+            del os.environ["VAULT_TOKEN"]
+        cl = hvac.Client(url=self.addr, token=self.token)
+        assert cl.is_authenticated()
+        return cl
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+
+    def is_running(self):
+        return self.process and not self.process.poll()
+
+    def _wait_until_active(self, timeout, poll):
+        self._message("Waiting for server to become active")
+        for i in range(math.ceil(timeout / poll)):
+            if not self.is_running():
+                self._process_output()
+                raise Exception("Vault process has terminated")
+            try:
+                cl = self.client()
+                if cl.sys.is_initialized():
+                    self._message("\nConnection made")
+                    return
+            except:
+                self._message(".", end="")
+                time.sleep(poll)
+        # self._process_output()
+        raise Exception("Vault did not start in time")
+
+    def _enable_kv1(self):
+        self._message("Configuring old-style kv engine at /secret")
+        cl = self.client()
+        cl.sys.disable_secrets_engine(path="secret")
+        cl.sys.enable_secrets_engine(backend_type="kv",
+                                     path="secret",
+                                     options={"version": 1})
+
+    def _message(self, txt, **kwargs):
+        if self.verbose:
+            print(txt, **kwargs)
+
+    def _process_output(self):
+        out = self.process.stdout.read().decode("UTF-8") or "(none)"
+        err = self.process.stderr.read().decode("UTF-8") or "(none)"
+        print("\nstdout:\n{}\nstderr:\n{}\n".format(out, err))

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -93,7 +93,6 @@ class server:
 
 class VaultDevServerError(Exception):
     def __init__(self, message, process):
-        self.message = message
         self.code = process.poll()
         if not self.code:
             print("Killing vault server process")
@@ -102,12 +101,12 @@ class VaultDevServerError(Exception):
         self.stdout = read_all_lines(process.stdout, ">> ")
         self.stderr = read_all_lines(process.stderr, ">> ")
 
-    def __str__(self):
         if self.code:
             status = "Process exited with code {}".format(self.code)
         else:
             status = "Process is still running"
         out = self.stdout or "(none)"
         err = self.stderr or "(none)"
-        return "{}\n{}\nstdout:\n{}\nstderr:\n{}".format(
-            self.message, status, out, err)
+        self.msg = message
+        self.message = "{}\n{}\nstdout:\n{}\nstderr:\n{}".format(
+            message, status, out, err)

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -12,10 +12,10 @@ from vault_dev.install import vault_path
 
 
 class server:
-    def __init__(self, port=None, verbose=False, debug=False, vault=None):
+    def __init__(self, port=None, verbose=False, debug=False):
         self.process = None
         self.verbose = verbose or debug
-        self.vault = vault_path(vault)
+        self.vault = vault_path()
         self.port = port or find_free_port()
         self.token = str(uuid.uuid4())
         self.debug = debug

--- a/vault_dev/server.py
+++ b/vault_dev/server.py
@@ -7,23 +7,25 @@ import uuid
 import hvac
 import requests
 
-from vault_dev.utils import find_free_port, read_all_lines, drop_envvar
+from vault_dev.utils import *
+from vault_dev.install import vault_path
 
 
 class server:
-    def __init__(self, port=None, verbose=False, debug=False):
+    def __init__(self, port=None, verbose=False, debug=False, vault=None):
+        self.process = None
+        self.verbose = verbose or debug
+        self.vault = vault_path(vault)
         self.port = port or find_free_port()
         self.token = str(uuid.uuid4())
         self.debug = debug
-        self.verbose = verbose or debug
-        self.process = None
 
     def start(self, timeout=5, poll=0.1):
         if self.is_running():
             self._message("Vault server already started")
             return
         self._message("Starting vault server on port {}".format(self.port))
-        args = ["vault", "server", "-dev",
+        args = [self.vault, "server", "-dev",
                 "-dev-listen-address", "localhost:{}".format(self.port),
                 "-dev-root-token-id", self.token]
         output = None if self.debug else subprocess.PIPE

--- a/vault_dev/utils.py
+++ b/vault_dev/utils.py
@@ -29,15 +29,3 @@ def read_all_lines(con, prefix=""):
 def drop_envvar(name):
     if name in os.environ:
         del os.environ[name]
-
-
-def find_executable(name, path):
-    if path:
-        if not os.path.exists(path):
-            raise Exception("Path '{}' does not exist".format(path))
-        path = os.path.abspath(path)
-    else:
-        path = shutil.which(name)
-        if not path:
-            raise OSError("Executable '{}' not found on path".format(name))
-    return path

--- a/vault_dev/utils.py
+++ b/vault_dev/utils.py
@@ -1,5 +1,6 @@
-import socket
 import errno
+import os
+import socket
 
 
 def find_free_port():
@@ -14,11 +15,16 @@ def find_free_port():
         return s.getsockname()[1]
 
 
-def port_is_in_use(port):
-    with socket.socket() as s:
-        try:
-            s.bind(("127.0.0.1", port))
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            return False
-        except socket.error as e:
-            return e.errno == errno.EADDRINUSE
+def read_all_lines(con, prefix=""):
+    output = []
+    while True:
+        d = con.readline()
+        if not d:
+            break
+        output.append(prefix + d.decode("UTF-8"))
+    return "".join(output)
+
+
+def drop_envvar(name):
+    if name in os.environ:
+        del os.environ[name]

--- a/vault_dev/utils.py
+++ b/vault_dev/utils.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import shutil
 import socket
 
 
@@ -28,3 +29,15 @@ def read_all_lines(con, prefix=""):
 def drop_envvar(name):
     if name in os.environ:
         del os.environ[name]
+
+
+def find_executable(name, path):
+    if path:
+        if not os.path.exists(path):
+            raise Exception("Path '{}' does not exist".format(path))
+        path = os.path.abspath(path)
+    else:
+        path = shutil.which(name)
+        if not path:
+            raise OSError("Executable '{}' not found on path".format(name))
+    return path

--- a/vault_dev/utils.py
+++ b/vault_dev/utils.py
@@ -1,0 +1,24 @@
+import socket
+import errno
+
+
+def find_free_port():
+    with socket.socket() as s:
+        # Let the OS pick a random free port on our machine
+        s.bind(('localhost', 0))
+        # Then mark this port as immediately ready for reuse - see
+        # https://docs.python.org/3.5/library/socket.html and search
+        # for SO_REUSEADDR
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Return the port number itself (getsockname is tuple (name, port))
+        return s.getsockname()[1]
+
+
+def port_is_in_use(port):
+    with socket.socket() as s:
+        try:
+            s.bind(("127.0.0.1", port))
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            return False
+        except socket.error as e:
+            return e.errno == errno.EADDRINUSE


### PR DESCRIPTION
This is required for the orderly web deployment work.

I have uploaded this version to pypi so the `pip` installation instructions should actually work.

There is a considerable amount of faff with ensuring that the vault executable is installed - that is needed in addition to `hvac` in order to run the test server.

The approach here is modelled largely off of that in `vaultr`